### PR TITLE
Fix bug where day/time clock was ignored for light/dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Tags will be separated with a comma, before it was separated with a space.
 ## Work in progress changes
 stay up to date https://trello.com/b/l4zH3Ne2/menudocs-written-guide
 
-- Accent colours
-- Stripping Unnecessary code back
-- Removal of loading pacman
-- Improve Colours on Categories and Tags
-- Change Paint Pallete to Cog
-- Remove Auto or actually make it work
-- Implement "to top" feature directly
+- [x] Remove Auto or actually make it work  
+- [ ] Accent colours  
+- [ ] Stripping Unnecessary code back  
+- [ ] Removal of loading pacman  
+- [ ] Improve Colours on Categories and Tags  
+- [ ] Change Paint Pallete to Cog  
+- [ ] Implement "to top" feature directly  

--- a/components/Mode/applyMode.js
+++ b/components/Mode/applyMode.js
@@ -26,10 +26,11 @@ export default function applyMode (mode) {
   if (isDarkMode) render('dark')
   if (isLightMode) render('light')
 
-  if (!isDarkMode && !isLightMode) {
-    console.log('You specified no preference for a color scheme or your browser does not support it. I schedule dark mode during night time.')
-    const hour = new Date().getHours()
-    if (hour < 6 || hour >= 18) render('dark')
-    else render('light')
-  }
+  /**
+   * 6 AM - 6 PM: Light mode
+   * 6 PM - 5 AM: Dark mode
+   */
+  const hour = new Date().getHours()
+  if (hour < 6 || hour >= 18) render('dark')
+  else render('light')
 }


### PR DESCRIPTION
For the daylight cycle to work in the previous iteration, matches for both light and dark mode media queries had to return false for the daylight cycle to work. However, the previous implementation broke the daylight cycle check overall.

The comment in the previous iteration of this function stated this is accounted for if older browsers are being used. I don't think this is really needed anymore as it's 2020, and these guides are geared towards developers. The daylight cycle should now function as normal.

Also, I updated the README with checkboxes.